### PR TITLE
lib: export rustix too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 
 // Re-export our dependencies
 pub use cap_std;
+#[cfg(not(windows))]
+pub use rustix;
 
 #[cfg(not(windows))]
 pub mod cmdext;


### PR DESCRIPTION
This exports our specific version of `rustix`. It is part of our
public API, e.g. through `OwnedFd` usage.